### PR TITLE
fix: Missing type reference link

### DIFF
--- a/types/iitc/index.d.ts
+++ b/types/iitc/index.d.ts
@@ -26,6 +26,7 @@
 /// <reference path="./ornaments.d.ts" />
 /// <reference path="./player_names.d.ts" />
 /// <reference path="./portal_data.d.ts" />
+/// <reference path="./portal_detail.d.ts" />
 /// <reference path="./portal_detail_display_tools.d.ts" />
 /// <reference path="./portal_detail_display.d.ts" />
 /// <reference path="./portal_hightlighter.d.ts" />


### PR DESCRIPTION
Add reference to `portal_detail.d.ts` in `types/iitc/index.d.ts`

This type is used on line 90 (previously 89): 
```typescript
portalDetail: PortalDetail;
```